### PR TITLE
Update 2024-06-30-lumbreras24a.md

### DIFF
--- a/_posts/2024-06-30-lumbreras24a.md
+++ b/_posts/2024-06-30-lumbreras24a.md
@@ -24,12 +24,12 @@ lastpage: 3682
 page: 3644-3682
 order: 3644
 cycles: false
-bibtex_author: Lumbreras, Josep and Tomamiche, Marco
+bibtex_author: Lumbreras, Josep and Tomamichel, Marco
 author:
 - given: Josep
   family: Lumbreras
 - given: Marco
-  family: Tomamiche
+  family: Tomamichel
 date: 2024-06-30
 address:
 container-title: Proceedings of Thirty Seventh Conference on Learning Theory


### PR DESCRIPTION
There is a missing "l" in the second author's last name, i.e. Marco Tomamichel.