### PR TITLE
Added missing title to 2024-06-30-koch24a.md

### DIFF
--- a/_posts/2024-06-30-koch24a.md
+++ b/_posts/2024-06-30-koch24a.md
@@ -1,5 +1,5 @@
 ---
-title: The title of the paper
+title: Superconstant Inapproximability of Decision Tree Learning
 section: Original Papers
 abstract: 'We consider the task of properly PAC learning decision trees with queries.
   Recent work of Koch, Strassle, and Tan showed that the strictest version of this
@@ -21,7 +21,7 @@ publisher: PMLR
 issn: 2640-3498
 id: koch24a
 month: 0
-tex_title: The title of the paper
+tex_title: Superconstant Inapproximability of Decision Tree Learning
 firstpage: 2979
 lastpage: 3010
 page: 2979-3010


### PR DESCRIPTION
Added missing title to our COLT 24 paper "Superconstant Inapproximability of Decision Tree Learning".